### PR TITLE
Confirmation emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ log/*
 .idea
 .ruby-version
 .ruby-gemset
+config/initializers/constants.rb

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,10 @@ group :development, :test do
   gem "pry-nav"
 end
 
+gem 'mandrill-api'
+gem 'mandrill_mailer'
+gem 'excon'
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     eventmachine (1.0.8)
+    excon (0.45.4)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.2)
@@ -64,6 +65,13 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    mandrill-api (1.0.53)
+      excon (>= 0.16.0, < 1.0)
+      json (>= 1.7.7, < 2.0)
+    mandrill_mailer (1.0.3)
+      actionpack
+      activesupport
+      mandrill-api (~> 1.0.9)
     method_source (0.8.2)
     mime-types (2.6.2)
     mini_portile (0.6.2)
@@ -157,6 +165,9 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   devise_token_auth
+  excon
+  mandrill-api
+  mandrill_mailer
   omniauth
   pg
   pry

--- a/app/controllers/api/v1/emails_controller.rb
+++ b/app/controllers/api/v1/emails_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::EmailsController < Api::V1::BaseController
+  before_action :ensure_admin_user
+
+  def send_welcome
+  	users = User.all
+    ConfirmationMailer.send_confirmation(users).deliver
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::UsersController < Api::V1::BaseController
       render json: {errors: "access denied"}, status: 403
     end
   end
-  
+
   def create
     # handled by Devise Token Auth
   end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,0 +1,37 @@
+class ConfirmationMailer < MandrillMailer::TemplateMailer
+
+  def send_confirmation(users)
+    users = Array.wrap(users) # in case you pass a single user object
+    emails = users.map{|user| {email: user.email, name: "#{user.first} #{user.last}"}}
+
+    mandrill_mail(
+      template: 'Donation Reminder',
+      to: emails,
+      important: true,
+      inline_css: true,
+      recipient_vars: users.map do |user|
+        { user.email =>
+          {
+            "FIRST_NAME" => user.first,
+            "USER_YES_DONATION_URL" => confirm_yes_url(user.id),
+            "USER_NO_DONATION_URL" => confirm_no_url
+          }
+        }
+      end
+     )
+  end
+
+  # I realize this isn't great but rails url helpers aren't available here 
+  # so I'm just hacking this together until a more elegant solution can be figured out post pilot
+  def confirm_yes_url(user_id)
+    default_host + "/users/#{user_id}/donations/new"
+  end
+
+  def confirm_no_url
+    default_host + "/sorrynotthistime"
+  end
+
+  def default_host
+    ActionMailer::Base.default_url_options[:host]
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,7 +1,5 @@
 Rails.application.configure do
   PASSWORD_RESET_URL = "http://www.localhost:4000/reset"
-
-  config.action_mailer.default_url_options = { :host => 'localhost' }
   
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,4 +80,5 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,10 @@
+Devise.setup do |config|
+  # The e-mail address that mail will appear to be sent from
+  # If absent, mail is sent from "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = "support@freshfoodconnect.org"
+
+  # If using rails-api, you may want to tell devise to not use ActionDispatch::Flash
+  # middleware b/c rails-api does not include it.
+  # See: http://stackoverflow.com/q/19600905/806956
+  config.navigational_formats = [:json]
+end

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,0 +1,10 @@
+ActionMailer::Base.smtp_settings = {
+  :address   => "smtp.mandrillapp.com",
+  :port      => 587,
+  :user_name => ENV['MANDRILL_USERNAME'],
+  :password  => ENV['MANDRILL_API_KEY'],
+  :domain    => ENV['SMTP_DOMAIN']
+}
+ActionMailer::Base.default_url_options = { host: ENV['SMTP_DOMAIN'] }
+ActionMailer::Base.delivery_method = :smtp
+ActionMailer::Base.default :from => ENV['FROM_EMAIL_ADDRESS']

--- a/config/initializers/mandrill_mailer.rb
+++ b/config/initializers/mandrill_mailer.rb
@@ -1,0 +1,4 @@
+MandrillMailer.configure do |config|
+  config.api_key = ENV['MANDRILL_API_KEY']
+  config.default_url_options = { host: ENV['SMTP_DOMAIN'] }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
       get 'donations', to: 'donations#list' # Admin Route
       get 'locations', to: 'locations#list' # Admin Route
 
+      post '/emails' => 'emails#create'
+
     end
   end
 end

--- a/spec/jobs/send_donation_email_job_spec.rb
+++ b/spec/jobs/send_donation_email_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SendDonationEmailJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This still has some ActiveJob stuff from previous work, but it's not bothering anything and eventually we may want to send emails via background jobs instead of synchronously. For now though, it's more overhead to kick off background workers, so not pursuing it. Otherwise it should pretty much be ready to go. 

One note is the the urls in the confirmation email sent in development will not have the port (e.g. 4000), so if you're testing the email-to-frontend flow, you'll have to add the port number to the url after you click it. In production, there won't be a port, so this won't be an issue.
