### PR TITLE
Slim-down users controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ gem 'spring', :group => :development
 gem 'pg'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'thin'
+gem 'mandrill-api'
+gem 'mandrill_mailer'
+gem 'excon'
+gem 'active_model_serializers'
 
 # authentication
 gem 'devise_token_auth'
@@ -21,9 +25,6 @@ group :development, :test do
   gem "pry-nav"
 end
 
-gem 'mandrill-api'
-gem 'mandrill_mailer'
-gem 'excon'
 
 # To use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.9.3)
+      activemodel (>= 3.2)
     activejob (4.2.4)
       activesupport (= 4.2.4)
       globalid (>= 0.3.0)
@@ -163,6 +165,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   awesome_print
   devise_token_auth
   excon
@@ -178,3 +181,6 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   spring
   thin
+
+BUNDLED WITH
+   1.10.6

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::BaseController < ApplicationController
   end
 
   def not_authorized(exception)
-    render json: { errors: exception.to_s }, status: :unauthorized
+    render json: { errors: exception.to_s }, status: :forbidden
   end
 
   def resource_not_found(exception)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,61 +1,15 @@
 class Api::V1::UsersController < Api::V1::BaseController
-  # before_action :admin_access_required, only: [:index]
+  before_action :ensure_admin_user, only: [ :index ]
 
   def index
-    if current_user.admin?
-      users = []
-      User.all.order(:id).each{|u| users << sanitize_user_attributes(u)}
-
-      render json: {users: users}
-    else
-      render json: {errors: "access denied"}, status: 403
-    end
+      users = User.all.order(:id)
+      render json: users, serializer: UserSerializer
   end
 
   def show
-    user = User.where(id:params[:id]).first
-
-    if current_user.admin? || user == current_user
-      render json: {user: sanitize_user_attributes(user)}
-    else
-      render json: {errors: "access denied"}, status: 403
-    end
-  end
-
-  def create
-    # handled by Devise Token Auth
-  end
-
-  def update
-   # handled by Devise Token Auth
-  end
-
-
-  private
-
-  def sanitize_user_attributes(u)
-    user_attributes = u.attributes
-    user_attributes.delete("provider")
-    user_attributes.delete("encrypted_password")
-    user_attributes.delete("reset_password_token")
-    user_attributes.delete("reset_password_sent_at")
-    user_attributes.delete("remember_created_at")
-    user_attributes.delete("sign_in_count")
-    user_attributes.delete("current_sign_in_at")
-    user_attributes.delete("last_sign_in_at")
-    user_attributes.delete("current_sign_in_ip")
-    user_attributes.delete("last_sign_in_ip")
-    user_attributes.delete("confirmation_token")
-    user_attributes.delete("confirmed_at")
-    user_attributes.delete("confirmation_sent_at")
-    user_attributes.delete("unconfirmed_email")
-    user_attributes.delete("tokens")
-    user_attributes.delete("created_at")
-    user_attributes.delete("updated_at")
-
-    user_attributes["role"] = u.role
-
-    user_attributes
+      raise Exceptions::AuthorizationError unless params[:id].to_i == current_user.id
+      user = User.find(params[:id])
+      render json: user, serializer: UserSerializer
   end
 
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,5 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :first, :last, :email, :role, :phone, :created_at, :updated_at
+
+  has_many :locations, :donations
+end


### PR DESCRIPTION
This commit moves presentation logic out of the UsersController and into
a UsersSerializer class that is responsible for representation of the
User resource in JSON. This commit also takes advantage of some of the
authorization filter helper methods added in previous commits.

If we like the pattern of using Serializers, then we can propagate this pattern to the remaining server resources.

Connects to https://waffle.io/codefordenver/fresh-food-connect/cards/561329d402b7e67a0066e6b7
