### PR TITLE
Revert "add confirmable back and update devise config to allow unconfirmed access for 7 days"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   # Include default devise modules.
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
-         :confirmable, :omniauthable
+         :omniauthable
 
   has_many :donations
   has_many :locations

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -7,6 +7,4 @@ Devise.setup do |config|
   # middleware b/c rails-api does not include it.
   # See: http://stackoverflow.com/q/19600905/806956
   config.navigational_formats = [:json]
-
-  config.allow_unconfirmed_access_for = 7.days
 end


### PR DESCRIPTION
This reverts commit 64a8e878a1996789216facf4183c17225114d38c.

Currently we just aren't ready for email verification. We need to update the email routes, and get the front end passing the data to the back end correctly. Finally, with the current code, the signup route doesn't send back the auth tokens, so the following actions are all unauthorized, causing a bad UX. Reverting this commit at least sends back the tokens, and allows us to delay the email verification until we have the pieces in place.
