### PR TITLE
add location attributes to params for signup

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::UsersController < DeviseTokenAuth::ApplicationController
+class Api::V1::UsersController < Api::V1::BaseController
   # before_action :admin_access_required, only: [:index]
 
   def index

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::UsersController < Api::V1::BaseController
+class Api::V1::UsersController < DeviseTokenAuth::ApplicationController
   # before_action :admin_access_required, only: [:index]
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::API
   protected
 
   def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:sign_up) << {locations_attributes: [:id, :address, :city, :state, :zipcode, :latitude, :longitude]}
     devise_parameter_sanitizer.for(:sign_up) << :email
     devise_parameter_sanitizer.for(:sign_up) << :password
     devise_parameter_sanitizer.for(:sign_up) << :password_confirmation
@@ -14,5 +15,6 @@ class ApplicationController < ActionController::API
     devise_parameter_sanitizer.for(:sign_up) << :last
     devise_parameter_sanitizer.for(:sign_up) << :role
     devise_parameter_sanitizer.for(:sign_up) << :phone
+    # binding.pry
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,7 +1,6 @@
 class Location < ActiveRecord::Base
   has_many :donations
   belongs_to :user
-  validates_presence_of :user_id
 
   enum pickup_day: ["Sunday", "Monday", "Tuesday", "Wednesday", 
   									"Thursday", "Friday", "Saturday"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ActiveRecord::Base
 
   has_many :donations
   has_many :locations
+  accepts_nested_attributes_for :locations
 
   include DeviseTokenAuth::Concerns::User
 


### PR DESCRIPTION
This allows clients to send location params with user signup so the location can be created without another request.

Closes #30 
